### PR TITLE
PHP 7.2 count() E_WARNING

### DIFF
--- a/src/ORM/MongoFinder.php
+++ b/src/ORM/MongoFinder.php
@@ -205,7 +205,11 @@ class MongoFinder
         $this->__sortOption($options);
         $this->__limitOption($options);
         $cursor = $this->connection()->find($this->_options['where'], $options);
-        $this->_totalRows = count($cursor);
+        if (is_array($cursor) || $cursor instanceof Countable) {
+            $this->_totalRows = count($cursor);
+        }else{
+            $this->_totalRows = 0;
+        }
 
         return $cursor;
     }


### PR DESCRIPTION
In the updates to PHP 7.2+, using count() as demonstrated above will emit a warning message.
An E_WARNING will now be emitted when attempting to count() non-countable types (this includes the sizeof() alias function).
Warning: count(): Parameter must be an array or an object that implements Countable 