### PR TITLE
Change the behavior of findFirst method.

### DIFF
--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -61,7 +61,7 @@ class Table extends CakeTable
             $mongoCursor = $query->{$method}();
             if ($mongoCursor instanceof \MongoDB\Model\BSONDocument) {
                 return (new Document($mongoCursor, $alias))->cakefy();
-            } elseif (is_array($mongoCursor)) {
+            } elseif (is_null($mongoCursor) || is_array($mongoCursor)) {
                 return $mongoCursor;
             }
             $results = new ResultSet($mongoCursor, $alias);


### PR DESCRIPTION
Changed behavior when record is not found with findFirst method.

Before:
```
Error: [TypeError] Argument 1 passed to Hayko\Mongodb\ORM\ResultSet::__construct() must be an instance of MongoDB\Driver\Cursor, null given, called in /var/www/html/vendor/hayko/mongodb/src/ORM/Table.php on line 67
```

After:
```
return null
```